### PR TITLE
docs(bl6): document declared_effects block in authoring + execution guides

### DIFF
--- a/lib/patterns/authoring-guide.md
+++ b/lib/patterns/authoring-guide.md
@@ -561,6 +561,7 @@ Three new optional front-matter fields in v8:
 - **`trust_mode`** (BL3) — enum `{stateless, gated}`, default `stateless`. Declarative metadata for runtimes; blueprint-lib validates the enum only.
 - **`data_mcps`** (BL4) — map of `<alias>` → `"<name>@<semver-range>"`. Declares which MCP servers the workflow depends on; aliases are used as prefixes in `mcp_tool_call.tool` references.
 - **`payload_types`** (BL2) — see Payload Types section above.
+- **`declared_effects`** (BL6, v8.1+) — optional per-alias effect envelope narrowing. Each alias maps to either the string literal `forbidden` or an object with optional `tools: [...]` and `max_call_count: N`. Cross-alias enforcement (tools-subset, alias-declared-in-`data_mcps`) is the consuming runtime's job; blueprint-lib validates only the syntactic shape.
 
 **Example front-matter:**
 
@@ -573,6 +574,31 @@ data_mcps:
 payload_types:
   query@1: { text: "string (min_length=1)" }
 ```
+
+#### Narrowing the effect envelope (`declared_effects`)
+
+Workflows that declare `data_mcps` accept any exported tool on any declared
+alias by default. To narrow that envelope — useful for sensitive workflows or
+for producing a machine-readable "effect manifest" — add a `declared_effects:`
+block:
+
+```yaml
+data_mcps:
+  crm:     "internal-crm@^2.1"
+  billing: "stripe-mcp@~3"
+
+declared_effects:
+  crm:
+    tools: [search_customers, get_account]   # read-only subset
+  billing:
+    tools: [create_invoice]
+    max_call_count: 1                        # hard cap across workflow run
+  shell: forbidden                           # explicit deny (documentation)
+```
+
+Over-declaration (listing tools the workflow never calls) is a warning from the
+consuming runtime, not an error — authors can narrow progressively during
+hardening.
 
 ---
 

--- a/lib/patterns/execution-guide.md
+++ b/lib/patterns/execution-guide.md
@@ -416,6 +416,22 @@ The runtime emits a tool *reference* in its response to the LLM agent. The LLM's
 - Topology A: runtime writes the resolved tool result at `store_as`.
 - Topology B: the LLM reports the tool result back; the runtime captures it and writes to `store_as` before the next `get_next_node` call.
 
+#### Effect-envelope enforcement
+
+Workflows may declare an explicit `declared_effects:` block (BL6, v8.1+) to
+narrow the default envelope inferred from `data_mcps`. Enforcement is a
+load-time static check, the consuming runtime's responsibility:
+
+- Reject any `mcp_tool_call` whose `tool` is not in the narrowed allowlist
+  (`tool_outside_envelope`).
+- Reject workflows whose reachable invocation count for an alias exceeds a
+  declared `max_call_count` (`count_exceeds_envelope`).
+- Warn on over-declaration (declared tools never invoked); not an error.
+
+Blueprint-lib validates only the block's syntactic shape. `declared_effects`
+narrows the envelope but does not widen it — cross-referencing against the
+aliased MCP server's published tools happens at the runtime boundary.
+
 ---
 
 ## 6. Precondition Dispatch


### PR DESCRIPTION
## Summary

Cross-repo sync for hiivmind-blueprint-lib v8.1.0 BL6 addition (companion PR: hiivmind/hiivmind-blueprint-lib#12).

- `lib/patterns/authoring-guide.md` — new `declared_effects` bullet in the "Workflow-level declarations (v8)" list plus a full `#### Narrowing the effect envelope` subsection with a `crm`/`billing`/`shell` worked example
- `lib/patterns/execution-guide.md` — new `#### Effect-envelope enforcement` subsection under the `mcp_tool_call` executor notes, documenting `tool_outside_envelope` / `count_exceeds_envelope` error codes and the over-declaration warning contract

### Source of truth

S2 spec §3 at hiivmind-blueprint-central (commit `c13d65e`) — the effect-envelope design BL6 is derived from.

## Test plan

- [ ] Markdown renders cleanly (nested fenced YAML block inside `####` subsection)
- [ ] Reads correctly alongside existing v8 guidance for `trust_mode`, `data_mcps`, `payload_types`
- [ ] Mergeable after blueprint-lib PR #12 merges and v8.1.0 is tagged (no hard dependency, but ordering is tidier)