### PR TITLE
docs: declared_effects docs + fix README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ This plugin provides 7 journey-oriented skills covering the full skill authoring
 ## Installation
 
 ```bash
-claude mcp add-skill-plugin hiivmind/hiivmind-blueprint-author
+claude plugin add /path/to/hiivmind-blueprint
+```
+
+Or install from GitHub:
+
+```bash
+claude plugin add hiivmind/hiivmind-blueprint
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Document the `declared_effects` block in authoring and execution guides (BL6)
- Fix README installation command from incorrect MCP syntax to correct `claude plugin add`

## Test plan
- [ ] Verify authoring-guide and execution-guide render correctly
- [ ] Confirm `claude plugin add` is the correct install syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)